### PR TITLE
fix createUniqueID for universal/isomorphic apps

### DIFF
--- a/modules/area-chart/index.js
+++ b/modules/area-chart/index.js
@@ -80,7 +80,7 @@ export default class AreaChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
   }
 
   componentDidMount() {

--- a/modules/bar-chart/index.js
+++ b/modules/bar-chart/index.js
@@ -89,7 +89,7 @@ export default class BarChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
   }
 
   componentDidMount() {

--- a/modules/legend/index.js
+++ b/modules/legend/index.js
@@ -31,7 +31,7 @@ export default class Legend extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID(); // Math.floor(Math.random() * new Date().getTime());
+    this.uid = createUniqueID(props);
   }
 
   getBackgroundColor(index) {

--- a/modules/line-chart/index.js
+++ b/modules/line-chart/index.js
@@ -80,7 +80,7 @@ export default class LineChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
   }
 
   componentDidMount() {

--- a/modules/pie-chart/hybrid/index.js
+++ b/modules/pie-chart/hybrid/index.js
@@ -59,7 +59,7 @@ export default class PieChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
     this.currentSlices = [];
     this.currentLabels = [];
     this.tweenSlice = (slice, index) => {

--- a/modules/pie-chart/static/index.js
+++ b/modules/pie-chart/static/index.js
@@ -58,7 +58,7 @@ export default class PieChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
   }
 
   getSliceArc() {

--- a/modules/scatterplot-chart/hybrid/index.js
+++ b/modules/scatterplot-chart/hybrid/index.js
@@ -91,7 +91,7 @@ export default class ScatterplotChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
   }
 
   componentDidMount() {

--- a/modules/scatterplot-chart/static/index.js
+++ b/modules/scatterplot-chart/static/index.js
@@ -91,7 +91,7 @@ export default class ScatterplotChart extends React.Component {
 
   constructor(props) {
     super(props);
-    this.uid = createUniqueID();
+    this.uid = createUniqueID(props);
   }
 
   componentDidMount() {

--- a/modules/shared.js
+++ b/modules/shared.js
@@ -1,6 +1,7 @@
 import { extent } from 'd3-array';
 import { scaleLinear as linear, scalePoint as point } from 'd3-scale';
 import { time, select } from 'd3';
+import hash from 'object-hash';
 
 export const defaultColors = [
   '#3F4C55',
@@ -157,8 +158,8 @@ export function getAxisStyles(grid, verticalGrid, yAxisOrientRight) {
   };
 }
 
-export function createUniqueID() {
-  return Math.floor(Math.random() * new Date().getTime());
+export function createUniqueID(obj) {
+  return hash(obj);
 }
 
 export function calculateMargin(axes, margin, yAxisOrientRight, y2) {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "dependencies": {
     "lodash.merge": "^4.0.1",
+    "object-hash": "^1.1.4",
     "radium": "^0.18.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR fixes an issue when doing server-side rendering for universal/isomorphic apps where you'd get a warning like this:

![image](https://cloud.githubusercontent.com/assets/31308/17310113/458ef16c-57f7-11e6-84c7-756ac97852bb.png)

Also, it'd be great if you could do a new NPM release #77 too regardless. Thanks!