### PR TITLE
update d3-time-format to clear the peerDependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "d3-array": "^0.8.1",
     "d3-scale": "^0.9.3",
     "d3-shape": "^0.7.1",
-    "d3-time-format": "^0.4.0",
+    "d3-time-format": "^2.0.3",
     "es5-shim": "^4.5.9",
     "es6-shim": "^0.35.1",
     "eslint": "^2.13.1",
@@ -96,7 +96,7 @@
     "d3-array": "^0.8.1",
     "d3-scale": "^0.9.3",
     "d3-shape": "^0.7.1",
-    "d3-time-format": "^0.4.0",
+    "d3-time-format": "^2.0.3",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-faux-dom": "^2.5.0"


### PR DESCRIPTION
update d3-time-format to latest version to clear the peerDependency warning when doing npm install