### PR TITLE
Updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "lodash.merge": "^4.0.1",
     "object-hash": "^1.1.4",
-    "radium": "^0.18.1"
+    "radium": "^0.19.1"
   },
   "peerDependencies": {
     "d3": "^3.5.17",


### PR DESCRIPTION
Radium 0.18 is having Proptype required from "react". Removes the warning: `Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`