### PR TITLE
add viewBox attribute

### DIFF
--- a/modules/line-chart/index.js
+++ b/modules/line-chart/index.js
@@ -103,6 +103,7 @@ export default class LineChart extends React.Component {
     const node = new ReactFauxDOM.Element('svg');
     node.setAttribute('width', w + m.left + m.right);
     node.setAttribute('height', h + m.top + m.bottom);
+    node.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
     return node;
   }
 


### PR DESCRIPTION
adds viewBox attribute so that SVG can be scalable with CSS instead of just using JS window resize event.