### PR TITLE
Use the new version of d3 v5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
-    "d3": "^4.12.0",
+    "d3": "^5.4.0",
     "d3-array": "^1.2.1",
-    "d3-scale": "^1.0.7",
+    "d3-scale": "^2.0.0",
     "d3-shape": "^1.2.0",
     "d3-time-format": "^2.1.1",
     "lodash.merge": "^4.0.1",


### PR DESCRIPTION
There is quite a lot of issues with the previous version of d3 4.12.0, because it was using d3-request.
If we use react-easy-chart in react application with Create React App, the application compilation fails with error described here:  https://nathanshane.me/blog/squashing-gatsby-webpack-d3-bug/
Since I don't want to eject my app, that is why I was forced to fork this project and propose this pull request